### PR TITLE
fix for copying/renaming file with twos/ones at the start of name

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function parseLine(line, result, context) {
   var rest = line.substr(2)
 
   var sanitycheck = rest.match(SANITY_REGEX)
-  if (!sanitycheck) return
+  if (!sanitycheck && first != '#') return //primitive, but might work
 
   switch (first) {
     case '#':

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var AHEAD_BEHIND_REGEX   = /^\+(\d+) -(\d+)$/
 var CHANGED_REGEX        = /^([.MADRCUT]{2}) ([NS][.C][.M][.U]) (\d+) (\d+) (\d+) ([0-9a-f]{40}) ([0-9a-f]{40}) (.*)$/
 var RENAMED_COPIED_REGEX = /^([.MADRCUT]{2}) ([NS][.C][.M][.U]) (\d+) (\d+) (\d+) ([0-9a-f]{40}) ([0-9a-f]{40}) ([RC]\d+) (.*)$/
 var UNMERGED_REGEX       = /^([.MADRCUT]{2}) ([NS][.C][.M][.U]) (\d+) (\d+) (\d+) (\d+) ([0-9a-f]{40}) ([0-9a-f]{40}) ([0-9a-f]{40}) (.*)$/
+var SANITY_REGEX         = /^([.MADRCUT]{2}) ([NS][.C][.M][.U]) (.*)$/
 
 function parse(str, limit) {
   return new Promise(function (resolve, reject) {
@@ -55,6 +56,9 @@ function parseLine(line, result, context) {
   if (!line.length) return
   var first = line[0];
   var rest = line.substr(2)
+
+  var sanitycheck = rest.match(SANITY_REGEX)
+  if (!sanitycheck) return
 
   switch (first) {
     case '#':

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var AHEAD_BEHIND_REGEX   = /^\+(\d+) -(\d+)$/
 var CHANGED_REGEX        = /^([.MADRCUT]{2}) ([NS][.C][.M][.U]) (\d+) (\d+) (\d+) ([0-9a-f]{40}) ([0-9a-f]{40}) (.*)$/
 var RENAMED_COPIED_REGEX = /^([.MADRCUT]{2}) ([NS][.C][.M][.U]) (\d+) (\d+) (\d+) ([0-9a-f]{40}) ([0-9a-f]{40}) ([RC]\d+) (.*)$/
 var UNMERGED_REGEX       = /^([.MADRCUT]{2}) ([NS][.C][.M][.U]) (\d+) (\d+) (\d+) (\d+) ([0-9a-f]{40}) ([0-9a-f]{40}) ([0-9a-f]{40}) (.*)$/
-var SANITY_REGEX         = /^([.MADRCUT]{2}) ([NS][.C][.M][.U]) (.*)$/
 
 function parse(str, limit) {
   return new Promise(function (resolve, reject) {
@@ -57,14 +56,8 @@ function parseLine(line, result, context) {
   var first = line[0];
   var rest = line.substr(2)
 
-  if (first == '2')
-  {
-    var sanitycheck = rest.match(SANITY_REGEX)
-    if (!sanitycheck)
-    {
-        first = '-'; // enforce switch to use default path instead of 2
-    }
-  }
+  // let's just ignore the "switch router" here if we expect next line to contain parsable rename or copy
+  if(context.inProgressRenameOrCopy){first='';}
 
   switch (first) {
     case '#':

--- a/index.js
+++ b/index.js
@@ -57,8 +57,14 @@ function parseLine(line, result, context) {
   var first = line[0];
   var rest = line.substr(2)
 
-  var sanitycheck = rest.match(SANITY_REGEX)
-  if (!sanitycheck && first != '#') return //primitive, but might work
+  if (first == '2')
+  {
+    var sanitycheck = rest.match(SANITY_REGEX)
+    if (!sanitycheck)
+    {
+        first = '-'; // enforce switch to use default path instead of 2
+    }
+  }
 
   switch (first) {
     case '#':

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -327,6 +327,56 @@ exports.testRenameOrCopyStatus = asyncTest(async function(test) {
   })
 })
 
+exports.testRenameOrCopyStatusWhenFilenameIsTwos = asyncTest(async function(test) {
+  var str = nlToNul(dedent`
+    # branch.oid 9b48b861ea745c83e4b3895298f6b5a0c869e43a
+    # branch.head master
+    # branch.upstream origin/master
+    # branch.ab +4 -15
+    2 C. N... 000000 100644 100644 0000000000000000000000000000000000000000 954cae3b40d4e4c24733b6b593783c3280d73933 C100 a.txt\0`+dedent`222.txt
+    2 R. N... 100644 100644 100644 9591561840608d8af4384d52d4b915d0a52f357b 9591561840608d8af4384d52d4b915d0a52f357b R100 b.txt\0`+dedent`2222.txt
+  `)
+
+  const output = await status.parse(str)
+  assert.deepEqual(output, {
+    branch: {
+      oid: '9b48b861ea745c83e4b3895298f6b5a0c869e43a',
+      head: 'master',
+      upstream: 'origin/master',
+      aheadBehind: { ahead: 4, behind: 15 }
+    },
+    changedEntries: [],
+    untrackedEntries: [],
+    renamedEntries: [
+      {
+        filePath: 'a.txt',
+        origFilePath: '222.txt',
+        stagedStatus: 'C',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '000000', index: '100644', worktree: '100644' },
+        headSha: '0000000000000000000000000000000000000000',
+        indexSha: '954cae3b40d4e4c24733b6b593783c3280d73933',
+        similarity: { type: 'C', score: 100 }
+      },
+      {
+        filePath: 'b.txt',
+        origFilePath: '2222.txt',
+        stagedStatus: 'R',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '100644', index: '100644', worktree: '100644' },
+        headSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        indexSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        similarity: { type: 'R', score: 100 }
+      }
+    ],
+    unmergedEntries: [],
+    ignoredEntries: []
+  })
+})
+
+
 exports.testTypechangeStatus = asyncTest(async function(test) {
   var str = nlToNul(dedent`
     # branch.oid c7ec6f89cccd6beca8d84023e9952137da316d16

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -523,7 +523,6 @@ exports.testRenameOrCopyStatusWhenFilenameIsLowerU = asyncTest(async function(te
   })
 })
 
-// This test might not be necessary (not sure if there may be questionmarks in paths on linux, windows seems not to like these)
 exports.testRenameOrCopyStatusWhenFilenameIsQuestionMarks = asyncTest(async function(test) {
   var str = nlToNul(dedent`
     # branch.oid 9b48b861ea745c83e4b3895298f6b5a0c869e43a

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -376,6 +376,251 @@ exports.testRenameOrCopyStatusWhenFilenameIsTwos = asyncTest(async function(test
   })
 })
 
+exports.testRenameOrCopyStatusWhenFilenameIsHash = asyncTest(async function(test) {
+  var str = nlToNul(dedent`
+    # branch.oid 9b48b861ea745c83e4b3895298f6b5a0c869e43a
+    # branch.head master
+    # branch.upstream origin/master
+    # branch.ab +4 -15
+    2 C. N... 000000 100644 100644 0000000000000000000000000000000000000000 954cae3b40d4e4c24733b6b593783c3280d73933 C100 a.txt\0`+dedent`#.txt
+    2 R. N... 100644 100644 100644 9591561840608d8af4384d52d4b915d0a52f357b 9591561840608d8af4384d52d4b915d0a52f357b R100 b.txt\0`+dedent`##.txt
+  `)
+
+  const output = await status.parse(str)
+  assert.deepEqual(output, {
+    branch: {
+      oid: '9b48b861ea745c83e4b3895298f6b5a0c869e43a',
+      head: 'master',
+      upstream: 'origin/master',
+      aheadBehind: { ahead: 4, behind: 15 }
+    },
+    changedEntries: [],
+    untrackedEntries: [],
+    renamedEntries: [
+      {
+        filePath: 'a.txt',
+        origFilePath: '#.txt',
+        stagedStatus: 'C',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '000000', index: '100644', worktree: '100644' },
+        headSha: '0000000000000000000000000000000000000000',
+        indexSha: '954cae3b40d4e4c24733b6b593783c3280d73933',
+        similarity: { type: 'C', score: 100 }
+      },
+      {
+        filePath: 'b.txt',
+        origFilePath: '##.txt',
+        stagedStatus: 'R',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '100644', index: '100644', worktree: '100644' },
+        headSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        indexSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        similarity: { type: 'R', score: 100 }
+      }
+    ],
+    unmergedEntries: [],
+    ignoredEntries: []
+  })
+})
+
+exports.testRenameOrCopyStatusWhenFilenameIsOnes = asyncTest(async function(test) {
+  var str = nlToNul(dedent`
+    # branch.oid 9b48b861ea745c83e4b3895298f6b5a0c869e43a
+    # branch.head master
+    # branch.upstream origin/master
+    # branch.ab +4 -15
+    2 C. N... 000000 100644 100644 0000000000000000000000000000000000000000 954cae3b40d4e4c24733b6b593783c3280d73933 C100 a.txt\0`+dedent`11.txt
+    2 R. N... 100644 100644 100644 9591561840608d8af4384d52d4b915d0a52f357b 9591561840608d8af4384d52d4b915d0a52f357b R100 b.txt\0`+dedent`111.txt
+  `)
+
+  const output = await status.parse(str)
+  assert.deepEqual(output, {
+    branch: {
+      oid: '9b48b861ea745c83e4b3895298f6b5a0c869e43a',
+      head: 'master',
+      upstream: 'origin/master',
+      aheadBehind: { ahead: 4, behind: 15 }
+    },
+    changedEntries: [],
+    untrackedEntries: [],
+    renamedEntries: [
+      {
+        filePath: 'a.txt',
+        origFilePath: '11.txt',
+        stagedStatus: 'C',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '000000', index: '100644', worktree: '100644' },
+        headSha: '0000000000000000000000000000000000000000',
+        indexSha: '954cae3b40d4e4c24733b6b593783c3280d73933',
+        similarity: { type: 'C', score: 100 }
+      },
+      {
+        filePath: 'b.txt',
+        origFilePath: '111.txt',
+        stagedStatus: 'R',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '100644', index: '100644', worktree: '100644' },
+        headSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        indexSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        similarity: { type: 'R', score: 100 }
+      }
+    ],
+    unmergedEntries: [],
+    ignoredEntries: []
+  })
+})
+
+exports.testRenameOrCopyStatusWhenFilenameIsLowerU = asyncTest(async function(test) {
+  var str = nlToNul(dedent`
+    # branch.oid 9b48b861ea745c83e4b3895298f6b5a0c869e43a
+    # branch.head master
+    # branch.upstream origin/master
+    # branch.ab +4 -15
+    2 C. N... 000000 100644 100644 0000000000000000000000000000000000000000 954cae3b40d4e4c24733b6b593783c3280d73933 C100 a.txt\0`+dedent`uu.txt
+    2 R. N... 100644 100644 100644 9591561840608d8af4384d52d4b915d0a52f357b 9591561840608d8af4384d52d4b915d0a52f357b R100 b.txt\0`+dedent`uuu.txt
+  `)
+
+  const output = await status.parse(str)
+  assert.deepEqual(output, {
+    branch: {
+      oid: '9b48b861ea745c83e4b3895298f6b5a0c869e43a',
+      head: 'master',
+      upstream: 'origin/master',
+      aheadBehind: { ahead: 4, behind: 15 }
+    },
+    changedEntries: [],
+    untrackedEntries: [],
+    renamedEntries: [
+      {
+        filePath: 'a.txt',
+        origFilePath: 'uu.txt',
+        stagedStatus: 'C',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '000000', index: '100644', worktree: '100644' },
+        headSha: '0000000000000000000000000000000000000000',
+        indexSha: '954cae3b40d4e4c24733b6b593783c3280d73933',
+        similarity: { type: 'C', score: 100 }
+      },
+      {
+        filePath: 'b.txt',
+        origFilePath: 'uuu.txt',
+        stagedStatus: 'R',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '100644', index: '100644', worktree: '100644' },
+        headSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        indexSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        similarity: { type: 'R', score: 100 }
+      }
+    ],
+    unmergedEntries: [],
+    ignoredEntries: []
+  })
+})
+
+// This test might not be necessary (not sure if there may be questionmarks in paths on linux, windows seems not to like these)
+exports.testRenameOrCopyStatusWhenFilenameIsQuestionMarks = asyncTest(async function(test) {
+  var str = nlToNul(dedent`
+    # branch.oid 9b48b861ea745c83e4b3895298f6b5a0c869e43a
+    # branch.head master
+    # branch.upstream origin/master
+    # branch.ab +4 -15
+    2 C. N... 000000 100644 100644 0000000000000000000000000000000000000000 954cae3b40d4e4c24733b6b593783c3280d73933 C100 a.txt\0`+dedent`??.txt
+    2 R. N... 100644 100644 100644 9591561840608d8af4384d52d4b915d0a52f357b 9591561840608d8af4384d52d4b915d0a52f357b R100 b.txt\0`+dedent`???.txt
+  `)
+
+  const output = await status.parse(str)
+  assert.deepEqual(output, {
+    branch: {
+      oid: '9b48b861ea745c83e4b3895298f6b5a0c869e43a',
+      head: 'master',
+      upstream: 'origin/master',
+      aheadBehind: { ahead: 4, behind: 15 }
+    },
+    changedEntries: [],
+    untrackedEntries: [],
+    renamedEntries: [
+      {
+        filePath: 'a.txt',
+        origFilePath: '??.txt',
+        stagedStatus: 'C',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '000000', index: '100644', worktree: '100644' },
+        headSha: '0000000000000000000000000000000000000000',
+        indexSha: '954cae3b40d4e4c24733b6b593783c3280d73933',
+        similarity: { type: 'C', score: 100 }
+      },
+      {
+        filePath: 'b.txt',
+        origFilePath: '???.txt',
+        stagedStatus: 'R',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '100644', index: '100644', worktree: '100644' },
+        headSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        indexSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        similarity: { type: 'R', score: 100 }
+      }
+    ],
+    unmergedEntries: [],
+    ignoredEntries: []
+  })
+})
+
+exports.testRenameOrCopyStatusWhenFilenameIsExclamations = asyncTest(async function(test) {
+  var str = nlToNul(dedent`
+    # branch.oid 9b48b861ea745c83e4b3895298f6b5a0c869e43a
+    # branch.head master
+    # branch.upstream origin/master
+    # branch.ab +4 -15
+    2 C. N... 000000 100644 100644 0000000000000000000000000000000000000000 954cae3b40d4e4c24733b6b593783c3280d73933 C100 a.txt\0`+dedent`!!.txt
+    2 R. N... 100644 100644 100644 9591561840608d8af4384d52d4b915d0a52f357b 9591561840608d8af4384d52d4b915d0a52f357b R100 b.txt\0`+dedent`!!!.txt
+  `)
+
+  const output = await status.parse(str)
+  assert.deepEqual(output, {
+    branch: {
+      oid: '9b48b861ea745c83e4b3895298f6b5a0c869e43a',
+      head: 'master',
+      upstream: 'origin/master',
+      aheadBehind: { ahead: 4, behind: 15 }
+    },
+    changedEntries: [],
+    untrackedEntries: [],
+    renamedEntries: [
+      {
+        filePath: 'a.txt',
+        origFilePath: '??.txt',
+        stagedStatus: 'C',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '000000', index: '100644', worktree: '100644' },
+        headSha: '0000000000000000000000000000000000000000',
+        indexSha: '954cae3b40d4e4c24733b6b593783c3280d73933',
+        similarity: { type: 'C', score: 100 }
+      },
+      {
+        filePath: 'b.txt',
+        origFilePath: '???.txt',
+        stagedStatus: 'R',
+        unstagedStatus: null,
+        submodule: { isSubmodule: false },
+        fileModes: { head: '100644', index: '100644', worktree: '100644' },
+        headSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        indexSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        similarity: { type: 'R', score: 100 }
+      }
+    ],
+    unmergedEntries: [],
+    ignoredEntries: []
+  })
+})
 
 exports.testTypechangeStatus = asyncTest(async function(test) {
   var str = nlToNul(dedent`

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -579,8 +579,8 @@ exports.testRenameOrCopyStatusWhenFilenameIsExclamations = asyncTest(async funct
     # branch.head master
     # branch.upstream origin/master
     # branch.ab +4 -15
-    2 C. N... 000000 100644 100644 0000000000000000000000000000000000000000 954cae3b40d4e4c24733b6b593783c3280d73933 C100 a.txt\0`+dedent`!!.txt
-    2 R. N... 100644 100644 100644 9591561840608d8af4384d52d4b915d0a52f357b 9591561840608d8af4384d52d4b915d0a52f357b R100 b.txt\0`+dedent`!!!.txt
+    2 C. N... 000000 100644 100644 0000000000000000000000000000000000000000 954cae3b40d4e4c24733b6b593783c3280d73934 C100 a.txt\0`+dedent`!!.txt
+    2 R. N... 100644 100644 100644 9591561840608d8af4384d52d4b915d0a52f3574 9591561840608d8af4384d52d4b915d0a52f3574 R100 b.txt\0`+dedent`!!!.txt
   `)
 
   const output = await status.parse(str)
@@ -596,24 +596,24 @@ exports.testRenameOrCopyStatusWhenFilenameIsExclamations = asyncTest(async funct
     renamedEntries: [
       {
         filePath: 'a.txt',
-        origFilePath: '??.txt',
+        origFilePath: '!!.txt',
         stagedStatus: 'C',
         unstagedStatus: null,
         submodule: { isSubmodule: false },
         fileModes: { head: '000000', index: '100644', worktree: '100644' },
         headSha: '0000000000000000000000000000000000000000',
-        indexSha: '954cae3b40d4e4c24733b6b593783c3280d73933',
+        indexSha: '954cae3b40d4e4c24733b6b593783c3280d73934',
         similarity: { type: 'C', score: 100 }
       },
       {
         filePath: 'b.txt',
-        origFilePath: '???.txt',
+        origFilePath: '!!!.txt',
         stagedStatus: 'R',
         unstagedStatus: null,
         submodule: { isSubmodule: false },
         fileModes: { head: '100644', index: '100644', worktree: '100644' },
-        headSha: '9591561840608d8af4384d52d4b915d0a52f357b',
-        indexSha: '9591561840608d8af4384d52d4b915d0a52f357b',
+        headSha: '9591561840608d8af4384d52d4b915d0a52f3574',
+        indexSha: '9591561840608d8af4384d52d4b915d0a52f3574',
         similarity: { type: 'R', score: 100 }
       }
     ],


### PR DESCRIPTION
I have created a copy of already existing case for copy/rename that includes a specific case I encountered (issue https://github.com/atom/atom/issues/21881) to help in solving the bug

Edit: Also proposing a potential solution

I don't see any `contributing` file, so I am unsure if I am creating the PR properly, but please at least consider including similar test in the test suite. 